### PR TITLE
Fix state label overflowing.

### DIFF
--- a/styles/app.less
+++ b/styles/app.less
@@ -228,7 +228,7 @@ ul, dl {
     cursor: default;
     height: 32px;
     line-height: 32px;
-    overflow-x: hidden;
+    overflow: hidden;
     padding: 0 8px;
     position: absolute;
     right: 0;


### PR DESCRIPTION
Fixes state label overflowing on Google Chrome on Windows. Chrome automatically displays scroll bars for overflowing content. 

![screen shot 2015-04-23 at 14 23 06](https://cloud.githubusercontent.com/assets/4517126/7307848/4aa844f2-e9c4-11e4-9d11-51f49b79554c.png)
